### PR TITLE
Corrigindo hyperlinks quebrados na bibliografia

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,9 +103,9 @@ Unidade 3
 
 Os principais recursos bibliográficos para esta disciplina estão disponíveis gratuitamente na Internet:
 
-- [learncpp.com](learncpp.com)
-- [cplusplus.com](cplusplus.com)
-- [cppreference.com](cppreference.com)
-- [roadmap.sh/cpp](roadmap.sh/cpp)
+- [learncpp.com](https://www.learncpp.com)
+- [cplusplus.com](https://cplusplus.com)
+- [cppreference.com](https://cppreference.com)
+- [roadmap.sh/cpp](htpps://roadmap.sh/cpp)
 
 

--- a/README.md
+++ b/README.md
@@ -103,9 +103,9 @@ Unidade 3
 
 Os principais recursos bibliográficos para esta disciplina estão disponíveis gratuitamente na Internet:
 
-- [learncpp.com](https://www.learncpp.com)
+- [learncpp.com](https://learncpp.com)
 - [cplusplus.com](https://cplusplus.com)
 - [cppreference.com](https://cppreference.com)
-- [roadmap.sh/cpp](htpps://roadmap.sh/cpp)
+- [roadmap.sh/cpp](https://roadmap.sh/cpp)
 
 


### PR DESCRIPTION
@danilocurvelo, olá professor. Tava olhando o site da disciplina e percebi o retorno 404 do github pages quando tentava acessar links da bibliografia, tomei liberdade de fazer um fork corrigindo isso. =D